### PR TITLE
feat(backend): Add admin functionality and fix server startup

### DIFF
--- a/backend/prisma/migrations/20251002025551_added_is_admin_to_user/migration.sql
+++ b/backend/prisma/migrations/20251002025551_added_is_admin_to_user/migration.sql
@@ -1,0 +1,16 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "isAdmin" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "password") SELECT "createdAt", "email", "id", "password" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   id            Int            @id @default(autoincrement())
   email         String         @unique
   password      String
+  isAdmin       Boolean        @default(false)
   createdAt     DateTime       @default(now())
   subscriptions Subscription[]
   usage         UsageTracking[]

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import authRoutes from './modules/auth/auth.routes';
 import aiRoutes from './modules/ai/ai.routes';
 import subscriptionRoutes from './modules/subscription/subscription.routes';
+import adminRoutes from './modules/admin/admin.routes';
 
 const app = express();
 
@@ -14,6 +15,7 @@ app.use(express.json());
 app.use('/api/auth', authRoutes);
 app.use('/api/ai', aiRoutes);
 app.use('/api/subscription', subscriptionRoutes);
+app.use('/api/admin', adminRoutes);
 
 // Simple test route
 app.get('/', (req, res) => {

--- a/backend/src/middleware/adminGuard.ts
+++ b/backend/src/middleware/adminGuard.ts
@@ -1,0 +1,25 @@
+import { Response, NextFunction } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { AuthRequest } from '../types/auth'; // Using a shared type definition
+
+const prisma = new PrismaClient();
+
+export const adminGuard = async (req: AuthRequest, res: Response, next: NextFunction) => {
+  if (!req.user) {
+    return res.status(401).json({ message: 'Authentication required.' });
+  }
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+    });
+
+    if (!user || !user.isAdmin) {
+      return res.status(403).json({ message: 'Forbidden: Admin access required.' });
+    }
+
+    next();
+  } catch (error) {
+    res.status(500).json({ message: 'Internal server error while verifying admin status.' });
+  }
+};

--- a/backend/src/middleware/authGuard.ts
+++ b/backend/src/middleware/authGuard.ts
@@ -1,12 +1,8 @@
-import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
+import { Response, NextFunction } from 'express';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import { AuthRequest } from '../types/auth';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-key';
-
-// Extend the Express Request type to include the user property
-interface AuthRequest extends Request {
-  user?: any;
-}
 
 export const authGuard = (req: AuthRequest, res: Response, next: NextFunction) => {
   const authHeader = req.headers['authorization'];
@@ -18,8 +14,16 @@ export const authGuard = (req: AuthRequest, res: Response, next: NextFunction) =
 
   try {
     const decoded = jwt.verify(token, JWT_SECRET);
-    req.user = decoded;
-    next();
+
+    if (typeof decoded === 'object' && 'id' in decoded && 'email' in decoded) {
+      req.user = {
+        id: (decoded as JwtPayload).id,
+        email: (decoded as JwtPayload).email,
+      };
+      next();
+    } else {
+      throw new Error('Invalid token payload.');
+    }
   } catch (error) {
     res.status(400).json({ message: 'Invalid token.' });
   }

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -1,0 +1,22 @@
+import { Response } from 'express';
+import { PrismaClient } from '@prisma/client';
+import { AuthRequest } from '../../types/auth';
+
+const prisma = new PrismaClient();
+
+export const AdminController = {
+  async getStats(req: AuthRequest, res: Response) {
+    try {
+      const totalUsers = await prisma.user.count();
+      const totalSubscriptions = await prisma.subscription.count();
+      // Add more stats as needed
+
+      res.status(200).json({
+        totalUsers,
+        totalSubscriptions,
+      });
+    } catch (error) {
+      res.status(500).json({ message: 'Error fetching admin stats.' });
+    }
+  },
+};

--- a/backend/src/modules/admin/admin.routes.ts
+++ b/backend/src/modules/admin/admin.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { AdminController } from './admin.controller';
+import { authGuard } from '../../middleware/authGuard';
+import { adminGuard } from '../../middleware/adminGuard';
+
+const router = Router();
+
+// Protect all admin routes with both auth and admin guards
+router.use(authGuard, adminGuard);
+
+router.get('/stats', AdminController.getStats);
+
+export default router;

--- a/backend/src/modules/ai/ai.controller.ts
+++ b/backend/src/modules/ai/ai.controller.ts
@@ -1,10 +1,6 @@
 import { Response } from 'express';
 import { AIService } from './ai.service';
-
-// Custom Request type to include the user property from our authGuard
-interface AuthRequest extends Request {
-  user?: { id: number };
-}
+import { AuthRequest } from '../../types/auth';
 
 export const AIController = {
   async generate(req: AuthRequest, res: Response) {

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -14,6 +14,7 @@ export const AuthController = {
       if (error.message === 'Email already in use') {
         return res.status(409).json({ message: error.message });
       }
+      console.error(error); // Log the actual error
       res.status(500).json({ message: 'Server error during sign up' });
     }
   },

--- a/backend/src/types/auth.ts
+++ b/backend/src/types/auth.ts
@@ -1,0 +1,8 @@
+import { Request } from 'express';
+
+export interface AuthRequest extends Request {
+  user?: {
+    id: number;
+    email: string;
+  };
+}


### PR DESCRIPTION
This commit introduces a new admin role and associated functionality to the backend, and resolves a critical TypeScript error that prevented the server from starting.

Key changes include:
- **Admin Role:** Added an `isAdmin` boolean field to the `User` model.
- **Admin API:** Created a new `/api/admin` endpoint with a `stats` route to provide administrative data.
- **Security:** Implemented an `adminGuard` middleware to protect admin-only routes.
- **Bug Fix:** Resolved a TypeScript type error in the `ai` module by creating a shared `AuthRequest` type, ensuring type consistency across the application.
- **Improved Logging:** Added error logging to the signup controller to improve diagnostics.

The backend is now stable and includes the foundational API for the admin dashboard. The frontend work for the admin UI and the requested redesign can now proceed.